### PR TITLE
feat: add ec2 ami for eu-west-3, change default broker instance type to avo…

### DIFF
--- a/templates/rocketmq-master.global.template
+++ b/templates/rocketmq-master.global.template
@@ -1,0 +1,725 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "(SO8006) - Deploy Apache RocketMQ Cluster on a New VPC in AWS",
+    "Metadata": {
+        "AWS::CloudFormation::Interface": {
+            "ParameterGroups": [
+                {
+                    "Label": {
+                        "default": "Network Configuration"
+                    },
+                    "Parameters": [
+                        "AvailabilityZones",
+                        "NumberOfAZs",
+                        "VPCCIDR",
+                        "PrivateSubnet1CIDR",
+                        "PrivateSubnet2CIDR",
+                        "PrivateSubnet3CIDR",
+                        "PublicSubnet1CIDR",
+                        "PublicSubnet2CIDR",
+                        "PublicSubnet3CIDR",
+                        "RemoteAccessCIDR"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Security Configuration"
+                    },
+                    "Parameters": [
+                        "KeyPairName"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Linux Bastion Amazon EC2 Configuration"
+                    },
+                    "Parameters": [
+                        "BastionAMIOS",
+                        "BastionInstanceType",
+                        "NumBastionHosts"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "RocketMQ Cluster Configuration"
+                    },
+                    "Parameters": [
+                        "NameServerClusterCount",
+                        "BrokerClusterCount",
+                        "Iops",
+                        "RocketMQVersion",
+                        "NameServerInstanceType",
+                        "BrokerNodeInstanceType",
+                        "FlushDiskType",
+                        "VolumeSize",
+                        "VolumeType"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "AWS Quick Start Configuration"
+                    },
+                    "Parameters": [
+                        "QSS3BucketName",
+                        "QSS3KeyPrefix",
+                        "QSS3BucketRegion"
+                    ]
+                }
+            ],
+            "ParameterLabels": {
+                "AvailabilityZones": {
+                    "default": "Availability Zones"
+                },
+                "BastionAMIOS": {
+                    "default": "Bastion AMI Operating System"
+                },
+                "BastionInstanceType": {
+                    "default": "Bastion Instance Type"
+                },
+                "NameServerClusterCount": {
+                    "default": "Number of Apache RocketMQ NameServer Cluster Node"
+                },
+                "BrokerClusterCount": {
+                    "default": "Number of Apache RocketMQ Broker Cluster Node"
+                },
+                "Iops": {
+                    "default": "IOPS"
+                },
+                "KeyPairName": {
+                    "default": "Key Pair Name"
+                },
+                "NumBastionHosts": {
+                    "default": "Number of Bastion Hosts"
+                },
+                "RocketMQVersion": {
+                    "default": "RocketMQ Version"
+                },
+                "NameServerInstanceType": {
+                    "default": "NameServer Intance type"
+                },
+                "BrokerNodeInstanceType": {
+                    "default": "Broker Node Instance Type"
+                },
+                "FlushDiskType": {
+                    "default": "Apache RocketMQ flush Disk Type"
+                },
+                "NumberOfAZs": {
+                    "default": "Number of Availability Zones"
+                },
+                "PrivateSubnet1CIDR": {
+                    "default": "Private Subnet 1 CIDR"
+                },
+                "PrivateSubnet2CIDR": {
+                    "default": "Private Subnet 2 CIDR"
+                },
+                "PrivateSubnet3CIDR": {
+                    "default": "Private Subnet 3 CIDR"
+                },
+                "PublicSubnet1CIDR": {
+                    "default": "Public Subnet 1 CIDR"
+                },
+                "PublicSubnet2CIDR": {
+                    "default": "Public Subnet 2 CIDR"
+                },
+                "PublicSubnet3CIDR": {
+                    "default": "Public Subnet 3 CIDR"
+                },
+                "QSS3BucketName": {
+                    "default": "Quick Start S3 Bucket Name"
+                },
+                "QSS3KeyPrefix": {
+                    "default": "Quick Start S3 Key Prefix"
+                },
+                "QSS3BucketRegion": {
+                    "default": "Quick Start S3 bucket region"
+                },
+                "RemoteAccessCIDR": {
+                    "default": "Allowed Bastion External Access CIDR"
+                },
+                "VolumeSize": {
+                    "default": "Volume Size"
+                },
+                "VolumeType": {
+                    "default": "Volume Type"
+                },
+                "VPCCIDR": {
+                    "default": "VPC CIDR"
+                }
+            }
+        }
+    },
+    "Parameters": {
+        "PrivateSubnet2CIDR": {
+            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "Default": "10.0.32.0/19",
+            "Type": "String",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
+            "Description": "CIDR block for private subnet 2 located in Availability Zone 2."
+        },
+          "PrivateSubnet3CIDR": {
+            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "Default": "10.0.64.0/19",
+            "Type": "String",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
+            "Description": "CIDR block for private subnet 3 located in Availability Zone 3."
+        },
+        "QSS3BucketName": {
+            "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$",
+            "Default": "rocketmq-test-us",
+            "Type": "String",
+            "ConstraintDescription": "Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).",
+            "Description": "S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
+        },
+        "PublicSubnet2CIDR": {
+            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "Default": "10.0.144.0/20",
+            "Type": "String",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
+            "Description": "CIDR Block for the public DMZ subnet 2 located in Availability Zone 2"
+        },
+          "PublicSubnet3CIDR": {
+            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "Default": "10.0.160.0/20",
+            "Type": "String",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
+            "Description": "CIDR Block for the public DMZ subnet 3 located in Availability Zone 3"
+        },
+        "KeyPairName": {
+            "Type": "AWS::EC2::KeyPair::KeyName",
+            "Description": "Public/private key pairs allow you to securely connect to your instance after it launches"
+        },
+        "PublicSubnet1CIDR": {
+            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "Default": "10.0.128.0/20",
+            "Type": "String",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
+            "Description": "CIDR Block for the public DMZ subnet 1 located in Availability Zone 1"
+        },
+        "BastionAMIOS": {
+            "AllowedValues": [
+                "Amazon-Linux-HVM",
+                "CentOS-7-HVM",
+                "Ubuntu-Server-14.04-LTS-HVM",
+                "Ubuntu-Server-16.04-LTS-HVM",
+                "Amazon-Linux2-HVM"
+            ],
+            "Default": "Amazon-Linux-HVM",
+            "Description": "The Linux distribution for the AMI to be used for the bastion instances",
+            "Type": "String"
+        },
+        "RemoteAccessCIDR": {
+            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+            "Type": "String",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
+            "Description": "Allowed CIDR block for external SSH access to the bastions"
+        },
+        "PrivateSubnet1CIDR": {
+            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "Default": "10.0.0.0/19",
+            "Type": "String",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
+            "Description": "CIDR block for private subnet 1 located in Availability Zone 1."
+        },
+        "BastionInstanceType": {
+            "Default": "t2.micro",
+            "Type": "String",
+            "Description": "Amazon EC2 instance type for the second bastion instance",
+            "AllowedValues": [
+                "t2.nano",
+                "t2.micro",
+                "t2.small",
+                "t2.medium",
+                "t2.large",
+                "m4.large",
+                "m4.xlarge",
+                "m4.2xlarge",
+                "m4.4xlarge"
+            ]
+        },
+        "NumBastionHosts": {
+            "AllowedValues": [
+                "1",
+                "2",
+                "3",
+                "4"
+            ],
+            "Default": "1",
+            "Description": "Enter the number of bastion hosts to create",
+            "Type": "String"
+        },
+        "VPCCIDR": {
+            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]))$",
+            "Default": "10.0.0.0/16",
+            "Type": "String",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/16-28",
+            "Description": "CIDR Block for the VPC"
+        },
+        "QSS3KeyPrefix": {
+            "AllowedPattern": "^[0-9a-zA-Z-/]*$",
+            "Default": "rocketmq/",
+            "Type": "String",
+            "ConstraintDescription": "Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/).",
+            "Description": "S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/). It cannot start or end with a hyphen (-)."
+        },
+        "QSS3BucketRegion": {
+            "Default": "us-east-1",
+            "Description": "The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value.",
+            "Type": "String"
+        },
+        "AvailabilityZones": {
+            "Type": "List<AWS::EC2::AvailabilityZone::Name>",
+            "Description": "List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved. 1 or 3 AZs are used for this deployment."
+        },
+        "NumberOfAZs": {
+            "AllowedValues": [
+                "2",
+                "3"
+            ],
+            "Description": "Number of Availability Zones to use in the VPC. This must match your selections in the list of Availability Zones parameter.",
+            "Type": "String"
+        },
+        "NameServerInstanceType": {
+            "Default": "m5.large",
+            "Type": "String",
+            "Description": "Amazon EC2 instance type for the RocketMQ nameserver nodes.",
+            "AllowedValues": [
+                "m5.large",
+                "m5.xlarge",
+                "m5.2xlarge",
+                "m5.4xlarge",
+                "m5.12xlarge",
+                "m5.24xlarge",
+                "r5.large",
+                "r5.xlarge",
+                "r5.2xlarge",
+                "r5.4xlarge",
+                "r5.8xlarge",
+                "r5.12xlarge",
+                "r5.16xlarge",
+                "r5.24xlarge",
+                "c5.large",
+                "c5.xlarge",
+                "c5.2xlarge",
+                "c5.4xlarge",
+                "c5.9xlarge",
+                "c5.18xlarge",
+                "r4.large",
+                "r4.xlarge",
+                "r4.2xlarge",
+                "r4.4xlarge",
+                "r4.8xlarge",
+                "r4.16xlarge",
+                "i3.large",
+                "i3.xlarge",
+                "i3.2xlarge",
+                "i3.4xlarge",
+                "i3.8xlarge",
+                "i3.16xlarge",
+                "m4.large",
+                "m4.xlarge",
+                "m4.2xlarge",
+                "m4.4xlarge",
+                "m4.10xlarge"
+            ]
+        },
+        "BrokerNodeInstanceType": {
+            "Default": "m5.2xlarge",
+            "Type": "String",
+            "Description": "Amazon EC2 instance type for the RocketMQ broker nodes.",
+            "AllowedValues": [
+                "m5.large",
+                "m5.xlarge",
+                "m5.2xlarge",
+                "m5.4xlarge",
+                "m5.12xlarge",
+                "m5.24xlarge",
+                "r5.large",
+                "r5.xlarge",
+                "r5.2xlarge",
+                "r5.4xlarge",
+                "r5.8xlarge",
+                "r5.12xlarge",
+                "r5.16xlarge",
+                "r5.24xlarge",
+                "c5.large",
+                "c5.xlarge",
+                "c5.2xlarge",
+                "c5.4xlarge",
+                "c5.9xlarge",
+                "c5.18xlarge",
+                "r4.large",
+                "r4.xlarge",
+                "r4.2xlarge",
+                "r4.4xlarge",
+                "r4.8xlarge",
+                "r4.16xlarge",
+                "i3.large",
+                "i3.xlarge",
+                "i3.2xlarge",
+                "i3.4xlarge",
+                "i3.8xlarge",
+                "i3.16xlarge",
+                "m4.large",
+                "m4.xlarge",
+                "m4.2xlarge",
+                "m4.4xlarge",
+                "m4.10xlarge"
+            ]
+        },
+        "VolumeSize": {
+            "Default": "400",
+            "Type": "String",
+            "Description": "EBS Volume Size (data) to be attached to node in GBs"
+        },
+        "VolumeType": {
+            "Default": "gp2",
+            "Type": "String",
+            "Description": "EBS Volume Type (data) to be attached to node in GBs [io1,gp2]",
+            "AllowedValues": [
+                "gp2",
+                "io1"
+            ]
+        },
+        "RocketMQVersion": {
+            "Default": "4.9.2",
+            "Type": "String",
+            "Description": "RocketMQ version",
+            "AllowedValues": [
+                "4.7.1",
+                "4.8.0",
+                "4.9.2",
+                "4.9.4",
+                "5.0.0",
+                "5.1.0",
+                "5.1.1"
+            ]
+        },
+        "NameServerClusterCount": {
+            "Default": "2",
+            "Type": "String",
+            "Description": "Number of Apache RocketMQ NameServer nodes. Choose between 1-3",
+            "AllowedValues": [
+                "1",
+                "2",
+                "3"
+            ]
+        },
+        "BrokerClusterCount": {
+            "Default": "3",
+            "Type": "String",
+            "Description": "Number of Replica Set Members. Choose 1 or 3",
+            "AllowedValues": [
+                "1",
+                "3"
+            ]
+        },
+        "FlushDiskType": {
+            "Default": "ASYNC_FLUSH",
+            "Type": "String",
+            "Description": "Apache RocketMQ flush Disk Type [ASYNC_FLUSH,SYNC_FLUSH]",
+            "AllowedValues": [
+                "ASYNC_FLUSH",
+                "SYNC_FLUSH"
+            ]
+        },
+        "Iops": {
+            "Default": "100",
+            "Type": "String",
+            "Description": "Iops of EBS volume when io1 type is chosen. Otherwise ignored"
+        }
+    },
+    "Conditions": {
+        "CreateThreeReplicaSet": {
+            "Fn::Equals": [
+                {
+                    "Ref": "BrokerClusterCount"
+                },
+                "3"
+            ]
+        },
+        "RepeatSubnet": {
+            "Fn::Equals": [
+                {
+                    "Ref": "NumberOfAZs"
+                },
+                "2"
+            ]
+        },
+        "GovCloudCondition": {
+            "Fn::Equals": [
+                {
+                    "Ref": "AWS::Region"
+                },
+                "us-gov-west-1"
+            ]
+        },
+        "UsingDefaultBucket": {
+            "Fn::Equals": [
+            {
+                "Ref": "QSS3BucketName"
+            },
+            "aws-cn-quickstart"
+            ]
+        }
+    },
+    "Resources" : {
+            "VPCStack": {
+            "Type": "AWS::CloudFormation::Stack",
+            "Properties": {
+                "TemplateURL": {
+                    "Fn::Sub": [
+                        "https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template",
+                        {
+                            "S3Region": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Ref" : "AWS::Region" }, {"Ref": "QSS3BucketRegion"}]
+                            },
+                            "S3Bucket": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
+                            }
+                        }
+                    ]
+                },
+                "Parameters": {
+                    "AvailabilityZones": {
+                        "Fn::Join": [
+                            ",",
+                            {
+                                "Ref": "AvailabilityZones"
+                            }
+                        ]
+                    },
+                    "KeyPairName": {
+                        "Ref": "KeyPairName"
+                    },
+                    "NumberOfAZs": {
+                        "Ref": "NumberOfAZs"
+                    },
+                    "PrivateSubnet1ACIDR": {
+                        "Ref": "PrivateSubnet1CIDR"
+                    },
+                    "PrivateSubnet2ACIDR": {
+                        "Ref": "PrivateSubnet2CIDR"
+                    },
+                    "PrivateSubnet3ACIDR": {
+                        "Ref": "PrivateSubnet3CIDR"
+                    },
+                    "PublicSubnet1CIDR": {
+                        "Ref": "PublicSubnet1CIDR"
+                    },
+                    "PublicSubnet2CIDR": {
+                        "Ref": "PublicSubnet2CIDR"
+                    },
+                    "PublicSubnet3CIDR": {
+                        "Ref": "PublicSubnet3CIDR"
+                    },
+                    "VPCCIDR": {
+                        "Ref": "VPCCIDR"
+                    }
+                }
+            }
+        },
+        "BastionStack": {
+            "Type": "AWS::CloudFormation::Stack",
+            "Properties": {
+                "TemplateURL": {
+                    "Fn::Sub": [
+                        "https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-linux-bastion/templates/linux-bastion.template",
+                        {
+                            "S3Region": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Ref": "AWS::Region" }, {"Ref": "QSS3BucketRegion"}]
+                            },
+                            "S3Bucket": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
+                            }
+                        }
+                    ]
+                },
+                "Parameters": {
+                    "BastionInstanceType": {
+                        "Ref": "BastionInstanceType"
+                    },
+                    "NumBastionHosts": {
+                        "Ref": "NumBastionHosts"
+                    },
+                    "BastionAMIOS": {
+                        "Ref": "BastionAMIOS"
+                    },
+                    "EnableTCPForwarding": "true",
+                    "KeyPairName": {
+                        "Ref": "KeyPairName"
+                    },
+                    "PublicSubnet1ID": {
+                        "Fn::GetAtt": [
+                            "VPCStack",
+                            "Outputs.PublicSubnet1ID"
+                        ]
+                    },
+                    "PublicSubnet2ID": {
+                        "Fn::GetAtt": [
+                            "VPCStack",
+                            "Outputs.PublicSubnet2ID"
+                        ]
+                    },
+                    "QSS3BucketName": {
+                        "Ref": "QSS3BucketName"
+                    },
+                    "QSS3KeyPrefix": {
+                        "Fn::Sub": "${QSS3KeyPrefix}submodules/quickstart-linux-bastion/"
+                    },
+                    "QSS3BucketRegion": {
+                        "Ref": "QSS3BucketRegion"
+                    },
+                    "RemoteAccessCIDR": {
+                        "Ref": "RemoteAccessCIDR"
+                    },
+                    "VPCID": {
+                        "Fn::GetAtt": [
+                            "VPCStack",
+                            "Outputs.VPCID"
+                        ]
+                    }
+                }
+            }
+        },
+        "RocketMQStack": {
+            "Type": "AWS::CloudFormation::Stack",
+            "Properties": {
+                "TemplateURL": {
+                    "Fn::Sub": [
+                        "https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/rocketmq.global.template",
+                        {
+                            "S3Region": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Ref": "AWS::Region" }, {"Ref": "QSS3BucketRegion"}]
+                            },
+                            "S3Bucket": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
+                            }
+                        }
+                    ]
+                },
+                "Parameters": {
+                    "QSS3BucketName": {
+                        "Ref": "QSS3BucketName"
+                    },
+                    "QSS3KeyPrefix": {
+                        "Ref": "QSS3KeyPrefix"
+                    },
+                    "QSS3BucketRegion": {
+                        "Ref": "QSS3BucketRegion"
+                    },
+                    "BastionSecurityGroupID": {
+                        "Fn::GetAtt": [
+                            "BastionStack",
+                            "Outputs.BastionSecurityGroupID"
+                        ]
+                    },
+                    "NameServerClusterCount": {
+                        "Ref": "NameServerClusterCount"
+                    },
+                    "BrokerClusterCount": {
+                        "Ref": "BrokerClusterCount"
+                    },
+                    "FlushDiskType": {
+                        "Ref": "FlushDiskType"
+                    },
+                    "Iops": {
+                        "Ref": "Iops"
+                    },
+                    "KeyPairName": {
+                        "Ref": "KeyPairName"
+                    },
+                    "NameServerInstanceType": {
+                        "Ref": "NameServerInstanceType"
+                    },
+                    "RocketMQVersion": {
+                        "Ref": "RocketMQVersion"
+                    },
+                    "BrokerNodeInstanceType": {
+                        "Ref": "BrokerNodeInstanceType"
+                    },
+                    "PrimaryNodeSubnet": {
+                        "Fn::GetAtt": [
+                            "VPCStack",
+                            "Outputs.PrivateSubnet1AID"
+                        ]
+                    },
+                    "Secondary0NodeSubnet": {
+                        "Fn::GetAtt": [
+                            "VPCStack",
+                            "Outputs.PrivateSubnet2AID"
+                        ]
+                    },
+                    "Secondary1NodeSubnet": {
+                        "Fn::If": [
+                            "RepeatSubnet",
+                            {
+                                "Fn::GetAtt": [
+                                    "VPCStack",
+                                    "Outputs.PrivateSubnet2AID"
+                                ]
+                            },
+                            {
+                                "Fn::GetAtt": [
+                                    "VPCStack",
+                                    "Outputs.PrivateSubnet3AID"
+                                ]
+                            }
+                        ]
+                    },
+                    "VPC": {
+                        "Fn::GetAtt": [
+                            "VPCStack",
+                            "Outputs.VPCID"
+                        ]
+                    },
+                    "VolumeSize": {
+                        "Ref": "VolumeSize"
+                    },
+                    "VolumeType": {
+                        "Ref": "VolumeType"
+                    }
+                }
+            }
+        }
+    },
+    "Outputs": {
+        "PrimaryReplicaNodeIp": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "RocketMQStack",
+                    "Outputs.PrimaryReplicaNodeIp"
+                ]
+            },
+            "Description": "Private IP Address of Primary Replica Node"
+        },
+        "SecondaryRocketMQBrokerNode0Ip": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "RocketMQStack",
+                    "Outputs.SecondaryRocketMQBrokerNode0Ip"
+                ]
+            },
+            "Description": "Private IP Address of Secondary Replica 0 Node",
+            "Condition" : "CreateThreeReplicaSet"
+        },
+        "SecondaryRocketMQBrokerNode1Ip": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "RocketMQStack",
+                    "Outputs.SecondaryRocketMQBrokerNode1Ip"
+                ]
+            },
+            "Description": "Private IP Address of Secondary Replica 1 Node",
+            "Condition" : "CreateThreeReplicaSet"
+        },
+        "RocketMQServerAccessSecurityGroup": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "RocketMQStack",
+                    "Outputs.RocketMQServerAccessSecurityGroup"
+                ]
+            },
+            "Description": "RocketMQ Access Security Group"
+        }
+    }
+}

--- a/templates/rocketmq-master.template
+++ b/templates/rocketmq-master.template
@@ -200,7 +200,8 @@
                 "Amazon-Linux-HVM",
                 "CentOS-7-HVM",
                 "Ubuntu-Server-14.04-LTS-HVM",
-                "Ubuntu-Server-16.04-LTS-HVM"
+                "Ubuntu-Server-16.04-LTS-HVM",
+                "Amazon-Linux2-HVM"
             ],
             "Default": "Amazon-Linux-HVM",
             "Description": "The Linux distribution for the AMI to be used for the bastion instances",
@@ -322,7 +323,7 @@
             ]
         },
         "BrokerNodeInstanceType": {
-            "Default": "m5.xlarge",
+            "Default": "m5.2xlarge",
             "Type": "String",
             "Description": "Amazon EC2 instance type for the RocketMQ broker nodes.",
             "AllowedValues": [

--- a/templates/rocketmq-node-broker.template
+++ b/templates/rocketmq-node-broker.template
@@ -85,11 +85,10 @@
         },
         "VolumeType": {
             "Type": "String",
-            "Description": "EBS Volume Type (data) to be attached to node in GBs [io1,gp2,gp3]",
-            "Default": "gp3",
+            "Description": "EBS Volume Type (data) to be attached to node in GBs [io1,gp2]",
+            "Default": "gp2",
             "AllowedValues": [
                 "gp2",
-                "gp3",
                 "io1"
             ]
         },
@@ -131,6 +130,7 @@
                 "4.9.2",
                 "4.9.4",
                 "5.0.0",
+                "5.1.0",
                 "5.1.1"
             ]
         },

--- a/templates/rocketmq-node-nameserver.template
+++ b/templates/rocketmq-node-nameserver.template
@@ -85,11 +85,10 @@
         },
         "VolumeType": {
             "Type": "String",
-            "Description": "EBS Volume Type (data) to be attached to node in GBs [io1,gp2,gp3]",
-            "Default": "gp3",
+            "Description": "EBS Volume Type (data) to be attached to node in GBs [io1,gp2]",
+            "Default": "gp2",
             "AllowedValues": [
                 "gp2",
-                "gp3",
                 "io1"
             ]
         },
@@ -132,6 +131,7 @@
                 "4.9.2",
                 "4.9.4",
                 "5.0.0",
+                "5.1.0",
                 "5.1.1"
             ]
         },

--- a/templates/rocketmq.global.template
+++ b/templates/rocketmq.global.template
@@ -1,0 +1,1220 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "(SO8006) - Deploy Apache RocketMQ Cluster on AWS (Existing VPC)",
+    "Metadata": {
+        "AWS::CloudFormation::Interface": {
+            "ParameterGroups": [
+                {
+                    "Label": {
+                        "default": "Network Configuration"
+                    },
+                    "Parameters": [
+                        "VPC",
+                        "PrimaryNodeSubnet",
+                        "Secondary0NodeSubnet",
+                        "Secondary1NodeSubnet",
+                        "BastionSecurityGroupID"
+                    ]
+                },
+                {
+                    "Label": {
+                        "default": "Security Configuration"
+                    },
+                    "Parameters": [
+                        "KeyPairName"
+                    ]
+                },
+                {
+                   "Label": {
+                        "default": "AWS Quick Start Configuration"
+                    },
+                    "Parameters": [
+                        "QSS3BucketName",
+                        "QSS3KeyPrefix",
+                        "QSS3BucketRegion"
+                    ]
+                }
+            ],
+            "ParameterLabels": {
+                "BastionSecurityGroupID": {
+                    "default": "Bastion Security Group ID"
+                },
+                "NameServerClusterCount": {
+                    "default": "Apache RocketMQ NameServer Cluster Node Count"
+                },
+                "BrokerClusterCount": {
+                    "default": "Cluster Replica Set Count"
+                },
+                "Iops": {
+                    "default": "Iops"
+                },
+                "KeyPairName": {
+                    "default": "Key Pair Name"
+                },
+                "NameServerInstanceType": {
+                    "default": "Nameserver Instance Type"
+                },
+                "BrokerNodeInstanceType": {
+                    "default": "Broker Instance Type"
+                },
+                "FlushDiskType": {
+                    "default": "Apache RocketMQ flush Disk Type"
+                },
+                "RocketMQVersion": {
+                    "Ref": "RocketMQVersion"
+                },
+                "PrimaryNodeSubnet": {
+                    "default": "Primary Node Subnet"
+                },
+                "QSS3BucketName": {
+                    "default": "Quick Start S3 Bucket Name"
+                },
+                "QSS3KeyPrefix": {
+                    "default": "Quick Start S3 Key Prefix"
+                },
+                "QSS3BucketRegion": {
+                    "default": "Quick Start S3 bucket region"
+                },
+                "Secondary0NodeSubnet": {
+                    "default": "Secondary0 Node Subnet"
+                },
+                "Secondary1NodeSubnet": {
+                    "default": "Secondary1 Node Subnet"
+                },
+                "VPC": {
+                    "default": "VPC"
+                },
+                "VolumeSize": {
+                    "default": "Volume Size"
+                },
+                "VolumeType": {
+                    "default": "Volume Type"
+                }
+            }
+        }
+    },
+    "Parameters": {
+        "BastionSecurityGroupID": {
+            "Description": "ID of the Bastion Security Group (e.g., sg-7f16e910)",
+            "Type": "AWS::EC2::SecurityGroup::Id"
+        },
+        "NameServerClusterCount": {
+            "Default": "2",
+            "Type": "String",
+            "Description": "Number of Apache RocketMQ NameServer nodes. Choose between 1-3",
+            "AllowedValues": [
+                "1",
+                "2",
+                "3"
+            ]
+        },
+        "BrokerClusterCount": {
+            "Description": "Number of Replica Set Members. Choose 1 or 3",
+            "Type": "String",
+            "Default": "3",
+            "AllowedValues": [
+                "1",
+                "3"
+            ]
+        },
+        "FlushDiskType": {
+            "Default": "ASYNC_FLUSH",
+            "Type": "String",
+            "Description": "Apache RocketMQ flush Disk Type [ASYNC_FLUSH,SYNC_FLUSH]",
+            "AllowedValues": [
+                "ASYNC_FLUSH",
+                "SYNC_FLUSH"
+            ]
+        },
+        "RocketMQVersion": {
+            "Default": "4.9.2",
+            "Type": "String",
+            "Description": "RocketMQ version",
+            "AllowedValues": [
+                "4.7.1",
+                "4.8.0",
+                "4.9.2",
+                "4.9.4",
+                "5.0.0",
+                "5.1.0",
+                "5.1.1"
+            ]
+        },
+        "QSS3BucketName": {
+            "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$",
+            "Default": "rocketmq-test-us",
+            "Type": "String",
+            "ConstraintDescription": "Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).",
+            "Description": "S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
+        },
+        "QSS3KeyPrefix": {
+            "AllowedPattern": "^[0-9a-zA-Z-/]*$",
+            "Default": "rocketmq/",
+            "Type": "String",
+            "ConstraintDescription": "Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/).",
+            "Description": "S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/). It cannot start or end with a hyphen (-)."
+        },
+        "QSS3BucketRegion": {
+            "Default": "us-east-1",
+            "Description": "The AWS Region where the Quick Start S3 bucket (QSS3BucketName) is hosted. When using your own bucket, you must specify this value.",
+            "Type": "String"
+        },
+        "KeyPairName": {
+            "Type": "AWS::EC2::KeyPair::KeyName",
+            "Default": "home",
+            "Description": "Name of an existing EC2 KeyPair. RocketMQ instances will launch with this KeyPair."
+        },
+        "VolumeSize": {
+            "Type": "String",
+            "Description": "EBS Volume Size (data) to be attached to node in GBs",
+            "Default": "100"
+        },
+        "VolumeType": {
+            "Type": "String",
+            "Description": "EBS Volume Type (data) to be attached to node in GBs [io1,gp2]",
+            "Default": "gp2",
+            "AllowedValues": [
+                "gp2",
+                "io1"
+            ]
+        },
+        "Iops": {
+            "Type": "String",
+            "Description": "Iops of EBS volume when io1 type is chosen. Otherwise ignored",
+            "Default": "100"
+        },
+        "NameServerInstanceType": {
+            "Description": "Amazon EC2 instance type for the RocketMQ Nameserver.",
+            "Type": "String",
+            "Default": "m5.large",
+            "AllowedValues": [
+                "m5.large",
+                "m5.xlarge",
+                "m5.2xlarge",
+                "m5.4xlarge",
+                "m5.12xlarge",
+                "m5.24xlarge",
+                "r5.large",
+                "r5.xlarge",
+                "r5.2xlarge",
+                "r5.4xlarge",
+                "r5.8xlarge",
+                "r5.12xlarge",
+                "r5.16xlarge",
+                "r5.24xlarge",
+                "c5.large",
+                "c5.xlarge",
+                "c5.2xlarge",
+                "c5.4xlarge",
+                "c5.9xlarge",
+                "c5.18xlarge",
+                "r4.large",
+                "r4.xlarge",
+                "r4.2xlarge",
+                "r4.4xlarge",
+                "r4.8xlarge",
+                "r4.16xlarge",
+                "i3.large",
+                "i3.xlarge",
+                "i3.2xlarge",
+                "i3.4xlarge",
+                "i3.8xlarge",
+                "i3.16xlarge",
+                "m4.large",
+                "m4.xlarge",
+                "m4.2xlarge",
+                "m4.4xlarge",
+                "m4.10xlarge"
+            ]
+        },
+        "BrokerNodeInstanceType": {
+            "Description": "Amazon EC2 instance type for the RocketMQ nodes.",
+            "Type": "String",
+            "Default": "m5.xlarge",
+            "AllowedValues": [
+                "m5.large",
+                "m5.xlarge",
+                "m5.2xlarge",
+                "m5.4xlarge",
+                "m5.12xlarge",
+                "m5.24xlarge",
+                "r5.large",
+                "r5.xlarge",
+                "r5.2xlarge",
+                "r5.4xlarge",
+                "r5.8xlarge",
+                "r5.12xlarge",
+                "r5.16xlarge",
+                "r5.24xlarge",
+                "c5.large",
+                "c5.xlarge",
+                "c5.2xlarge",
+                "c5.4xlarge",
+                "c5.9xlarge",
+                "c5.18xlarge",
+                "r4.large",
+                "r4.xlarge",
+                "r4.2xlarge",
+                "r4.4xlarge",
+                "r4.8xlarge",
+                "r4.16xlarge",
+                "i3.large",
+                "i3.xlarge",
+                "i3.2xlarge",
+                "i3.4xlarge",
+                "i3.8xlarge",
+                "i3.16xlarge",
+                "m4.large",
+                "m4.xlarge",
+                "m4.2xlarge",
+                "m4.4xlarge",
+                "m4.10xlarge"
+            ]
+        },
+        "VPC": {
+            "Type": "AWS::EC2::VPC::Id",
+            "Description": "VPC-ID of your existing Virtual Private Cloud (VPC) where you want to depoy RocketMQ cluster."
+        },
+        "PrimaryNodeSubnet": {
+            "Type": "AWS::EC2::Subnet::Id",
+            "Description": "Subnet-ID the existing subnet in your VPC where you want to deploy Primary node(s)."
+        },
+        "Secondary0NodeSubnet": {
+            "Type": "AWS::EC2::Subnet::Id",
+            "Description": "Subnet-ID the existing subnet in your VPC where you want to deploy Secondary node(s)."
+        },
+        "Secondary1NodeSubnet": {
+            "Type": "AWS::EC2::Subnet::Id",
+            "Description": "Subnet-ID the existing subnet in your VPC where you want to deploy Secondary node(s)."
+        }
+    },
+    "Conditions": {
+        "Launch1NameServer": {
+            "Fn::Equals": [
+                1,
+                1
+            ]
+        },
+        "Launch2NameServer": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        1,
+                        {
+                            "Ref": "NameServerClusterCount"
+                        }
+                    ]
+                }
+            ]
+        },
+        "Launch3NameServer": {
+            "Fn::And": [
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                1,
+                                {
+                                    "Ref": "NameServerClusterCount"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "Fn::Not": [
+                        {
+                            "Fn::Equals": [
+                                2,
+                                {
+                                    "Ref": "NameServerClusterCount"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        "CreateThreeReplicaSet": {
+            "Fn::Equals": [
+                {
+                    "Ref": "BrokerClusterCount"
+                },
+                "3"
+            ]
+        },
+        "CnRegionCondition": {
+            "Fn::Or": [
+                {
+                    "Fn::Equals": [ { "Ref": "AWS::Region" }, "cn-north-1" ]
+                },
+                {
+                    "Fn::Equals":[ { "Ref": "AWS::Region" }, "cn-northwest-1" ]
+                }
+            ]
+        },
+        "UsingDefaultBucket": {
+            "Fn::Equals": [
+            {
+                "Ref": "QSS3BucketName"
+            },
+            "aws-cn-quickstart"
+            ]
+        }
+    },
+    "Mappings": {
+        "AWSAMIRegionMap": {
+            "AMI": {
+                "AMZNLINUX": "amzn2-ami-hvm-2.0.20201218.1-x86_64-gp2"
+            },
+            "ap-northeast-1": {
+                "AMZNLINUX": "ami-09d28faae2e9e7138"
+            },
+            "ap-northeast-2": {
+                "AMZNLINUX": "ami-006e2f9fa7597680a"
+            },
+            "ap-south-1": {
+                "AMZNLINUX": "ami-0eeb03e72075b9bcc"
+            },
+            "ap-southeast-1": {
+                "AMZNLINUX": "ami-0d06583a13678c938"
+            },
+            "ap-southeast-2": {
+                "AMZNLINUX": "ami-075a72b1992cb0687"
+            },
+            "ca-central-1": {
+                "AMZNLINUX": "ami-0d06583a13678c938"
+            },
+            "eu-central-1": {
+                "AMZNLINUX": "ami-0df612970f825f04c"
+            },
+            "eu-west-1": {
+                "AMZNLINUX": "ami-096f43ef67d75e998"
+            },
+            "eu-west-2": {
+                "AMZNLINUX": "ami-0ffd774e02309201f"
+            },
+            "sa-east-1": {
+                "AMZNLINUX": "ami-0a0bc0fa94d632c94"
+            },
+            "us-east-1": {
+                "AMZNLINUX": "ami-0be2609ba883822ec"
+            },
+            "us-east-2": {
+                "AMZNLINUX": "ami-09246ddb00c7c4fef"
+            },
+            "us-west-1": {
+                "AMZNLINUX": "ami-066c82dabe6dd7f73"
+            },
+            "us-west-2": {
+                "AMZNLINUX": "ami-09c5e030f74651050"
+            },
+            "cn-north-1":{
+                "AMZNLINUX": "ami-0e73c8a64c3afcefa"
+            },
+            "cn-northwest-1":{
+                "AMZNLINUX": "ami-0c6205ef045ce3916"
+            },
+            "eu-west-3":{
+                "AMZNLINUX": "ami-04b7bf9494d21c5bb"
+            }
+        }
+    },
+    "Resources": {
+        "RocketMQServerAccessSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "GroupDescription": "Instances with access to RocketMQ servers"
+            }
+        },
+        "RocketMQNameServerSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "GroupDescription": "RocketMQ server management and access ports",
+                "SecurityGroupIngress": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 22,
+                        "ToPort": 22,
+                        "SourceSecurityGroupId": {
+                            "Ref": "BastionSecurityGroupID"
+                        }
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 9876,
+                        "ToPort": 9876,
+                        "CidrIp" : "0.0.0.0/0"
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 8080,
+                        "ToPort": 8080,
+                        "CidrIp" : "0.0.0.0/0"
+                    }
+                ]
+            }
+        },
+        "RocketMQBrokerServerSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "VpcId": {
+                    "Ref": "VPC"
+                },
+                "GroupDescription": "RocketMQ server management and access ports",
+                "SecurityGroupIngress": [
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 22,
+                        "ToPort": 22,
+                        "SourceSecurityGroupId": {
+                            "Ref": "BastionSecurityGroupID"
+                        }
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 30909,
+                        "ToPort": 30999,
+                        "CidrIp" : "0.0.0.0/0"
+
+                    },
+                    {
+                        "IpProtocol": "tcp",
+                        "FromPort": 40911,
+                        "ToPort": 40999,
+                        "CidrIp" : "0.0.0.0/0"
+
+                    }
+                ]
+            }
+        },
+        "RocketMQNodeIAMRole": {
+            "Type": "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Principal": {
+                                "Service": [
+                                    { "Fn::Sub": "ec2.${AWS::URLSuffix}" }
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path": "/",
+                "Policies": [
+                    {
+                        "PolicyName": "rocketmq-quickstart-policy",
+                        "PolicyDocument": {
+                            "Statement": [
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "ec2:Describe*",
+                                        "ec2:AttachNetworkInterface",
+                                        "ec2:AttachVolume",
+                                        "ec2:CreateTags",
+                                        "ec2:CreateVolume",
+                                        "ec2:RunInstances",
+                                        "ec2:StartInstances",
+                                        "ec2:DeleteVolume",
+                                        "ec2:CreateSecurityGroup",
+                                        "ec2:CreateSnapshot"
+                                    ],
+                                    "Resource": "*"
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "s3:GetObject"
+                                    ],
+                                    "Resource": {
+                                        "Fn::Sub": [
+                                           "arn:${AWS::Partition}:s3:::${S3Bucket}/${QSS3KeyPrefix}*",
+                                           {
+                                               "S3Bucket": {
+                                                   "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
+                                               }
+                                           }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "Effect": "Allow",
+                                    "Action": [
+                                        "dynamodb:BatchGetItem",
+                                        "dynamodb:CreateTable",
+                                        "dynamodb:DeleteTable",
+                                        "dynamodb:DescribeTable",
+                                        "dynamodb:GetItem",
+                                        "dynamodb:PutItem",
+                                        "dynamodb:Query",
+                                        "dynamodb:Scan",
+                                        "dynamodb:UpdateItem",
+                                        "dynamodb:UpdateTable"
+                                    ],
+                                    "Resource": [
+                                        {
+                                            "Fn::Sub": "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/*ROCKETMQ_*"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "RocketMQNodeIAMProfile": {
+            "Type": "AWS::IAM::InstanceProfile",
+            "Properties": {
+                "Path": "/",
+                "Roles": [
+                    {
+                        "Ref": "RocketMQNodeIAMRole"
+                    }
+                ]
+            }
+        },
+        "RocketMQNameServerNode0WaitForNodeInstallWaitHandle": {
+            "Type": "AWS::CloudFormation::WaitConditionHandle",
+            "Condition": "Launch1NameServer",
+            "Properties": {}
+        },
+        "RocketMQNameServerNode0": {
+            "Type": "AWS::CloudFormation::Stack",
+            "Condition": "Launch1NameServer",
+            "Properties": {
+                "TemplateURL": {
+                    "Fn::Sub": [
+                        "https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/rocketmq-node-nameserver.template",
+                        {
+                            "S3Region": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Ref": "AWS::Region" }, {"Ref": "QSS3BucketRegion"}]
+                            },
+                            "S3Bucket": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
+                            }
+                        }
+                    ]
+                },
+                "Parameters": {
+                    "QSS3BucketName": {
+                        "Ref": "QSS3BucketName"
+                    },
+                    "QSS3KeyPrefix": {
+                        "Ref": "QSS3KeyPrefix"
+                    },
+                    "QSS3BucketRegion": {
+                        "Ref": "QSS3BucketRegion"
+                    },
+                    "NameServerClusterCount": {
+                        "Ref": "NameServerClusterCount"
+                    },
+                    "BrokerClusterCount": {
+                        "Ref": "BrokerClusterCount"
+                    },
+                    "RocketMQVersion": {
+                        "Ref": "RocketMQVersion"
+                    },
+                    "Iops": {
+                        "Ref": "Iops"
+                    },
+                    "KeyName": {
+                        "Ref": "KeyPairName"
+                    },
+                    "BrokerNodeInstanceType": {
+                        "Ref": "NameServerInstanceType"
+                    },
+                    "NodeSubnet": {
+                        "Ref": "PrimaryNodeSubnet"
+                    },
+                    "RocketMQNameServerSecurityGroupID": {
+                        "Ref": "RocketMQNameServerSecurityGroup"
+                    },
+                    "RocketMQNodeIAMProfileID": {
+                        "Ref": "RocketMQNodeIAMProfile"
+                    },
+                    "VPC": {
+                        "Ref": "VPC"
+                    },
+                    "VolumeSize": {
+                        "Ref": "VolumeSize"
+                    },
+                    "VolumeType": {
+                        "Ref": "VolumeType"
+                    },
+                    "StackName": {
+                        "Ref": "AWS::StackName"
+                    },
+                    "ImageId": {
+                        "Fn::FindInMap": [
+                            "AWSAMIRegionMap",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            "AMZNLINUX"
+                        ]
+                    },
+                    "ReplicaNodeNameTag": "PrimaryRocketMQ-NameServer-Node-0",
+                    "NodeReplicaSetIndex": "0",
+                    "ReplicaNodeWaitForNodeInstallWaitHandle": {
+                        "Ref": "RocketMQNameServerNode0WaitForNodeInstallWaitHandle"
+                    }
+                }
+            }
+        },
+        "RocketMQNameServerNode0WaitForNodeInstall": {
+            "Type": "AWS::CloudFormation::WaitCondition",
+            "Condition": "Launch1NameServer",
+            "DependsOn": "RocketMQNameServerNode0",
+            "Properties": {
+                "Handle": {
+                    "Ref": "RocketMQNameServerNode0WaitForNodeInstallWaitHandle"
+                },
+                "Timeout": "3600"
+            }
+        },
+        "RocketMQNameServerNode1WaitForNodeInstallWaitHandle": {
+            "Type": "AWS::CloudFormation::WaitConditionHandle",
+            "Properties": {}
+        },
+        "RocketMQNameServerNode1": {
+            "Type": "AWS::CloudFormation::Stack",
+            "Condition": "Launch2NameServer",
+            "Properties": {
+                "TemplateURL": {
+                    "Fn::Sub": [
+                        "https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/rocketmq-node-nameserver.template",
+                        {
+                            "S3Region": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Ref": "AWS::Region" }, {"Ref": "QSS3BucketRegion"}]
+                            },
+                            "S3Bucket": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
+                            }
+                        }
+                    ]
+                },
+                "Parameters": {
+                    "QSS3BucketName": {
+                        "Ref": "QSS3BucketName"
+                    },
+                    "QSS3KeyPrefix": {
+                        "Ref": "QSS3KeyPrefix"
+                    },
+                    "QSS3BucketRegion": {
+                        "Ref": "QSS3BucketRegion"
+                    },
+                    "NameServerClusterCount": {
+                        "Ref": "NameServerClusterCount"
+                    },
+                    "BrokerClusterCount": {
+                        "Ref": "BrokerClusterCount"
+                    },
+                    "RocketMQVersion": {
+                        "Ref": "RocketMQVersion"
+                    },
+                    "Iops": {
+                        "Ref": "Iops"
+                    },
+                    "KeyName": {
+                        "Ref": "KeyPairName"
+                    },
+                    "BrokerNodeInstanceType": {
+                        "Ref": "NameServerInstanceType"
+                    },
+                    "NodeSubnet": {
+                        "Ref": "PrimaryNodeSubnet"
+                    },
+                    "RocketMQNameServerSecurityGroupID": {
+                        "Ref": "RocketMQNameServerSecurityGroup"
+                    },
+                    "RocketMQNodeIAMProfileID": {
+                        "Ref": "RocketMQNodeIAMProfile"
+                    },
+                    "VPC": {
+                        "Ref": "VPC"
+                    },
+                    "VolumeSize": {
+                        "Ref": "VolumeSize"
+                    },
+                    "VolumeType": {
+                        "Ref": "VolumeType"
+                    },
+                    "StackName": {
+                        "Ref": "AWS::StackName"
+                    },
+                    "ImageId": {
+                        "Fn::FindInMap": [
+                            "AWSAMIRegionMap",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            "AMZNLINUX"
+                        ]
+                    },
+                    "ReplicaNodeNameTag": "RocketMQ-NameServer-Node-1",
+                    "NodeReplicaSetIndex": "1",
+                    "ReplicaNodeWaitForNodeInstallWaitHandle": {
+                        "Ref": "RocketMQNameServerNode1WaitForNodeInstallWaitHandle"
+                    }
+                }
+            }
+        },
+        "RocketMQNameServerNode1WaitForNodeInstall": {
+            "Type": "AWS::CloudFormation::WaitCondition",
+            "Condition": "Launch2NameServer",
+            "DependsOn": "RocketMQNameServerNode1",
+            "Properties": {
+                "Handle": {
+                    "Ref": "RocketMQNameServerNode1WaitForNodeInstallWaitHandle"
+                },
+                "Timeout": "3600"
+            }
+        },
+        "RocketMQNameServerNode2WaitForNodeInstallWaitHandle": {
+            "Type": "AWS::CloudFormation::WaitConditionHandle",
+            "Properties": {}
+        },
+        "RocketMQNameServerNode2": {
+            "Type": "AWS::CloudFormation::Stack",
+            "Condition": "Launch3NameServer",
+            "Properties": {
+                "TemplateURL": {
+                    "Fn::Sub": [
+                        "https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/rocketmq-node-nameserver.template",
+                        {
+                            "S3Region": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Ref": "AWS::Region" }, {"Ref": "QSS3BucketRegion"}]
+                            },
+                            "S3Bucket": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
+                            }
+                        }
+                    ]
+                },
+                "Parameters": {
+                    "QSS3BucketName": {
+                        "Ref": "QSS3BucketName"
+                    },
+                    "QSS3KeyPrefix": {
+                        "Ref": "QSS3KeyPrefix"
+                    },
+                    "QSS3BucketRegion": {
+                        "Ref": "QSS3BucketRegion"
+                    },
+                    "NameServerClusterCount": {
+                        "Ref": "NameServerClusterCount"
+                    },
+                    "BrokerClusterCount": {
+                        "Ref": "BrokerClusterCount"
+                    },
+                    "RocketMQVersion": {
+                        "Ref": "RocketMQVersion"
+                    },
+                    "Iops": {
+                        "Ref": "Iops"
+                    },
+                    "KeyName": {
+                        "Ref": "KeyPairName"
+                    },
+                    "BrokerNodeInstanceType": {
+                        "Ref": "NameServerInstanceType"
+                    },
+                    "NodeSubnet": {
+                        "Ref": "PrimaryNodeSubnet"
+                    },
+                    "RocketMQNameServerSecurityGroupID": {
+                        "Ref": "RocketMQNameServerSecurityGroup"
+                    },
+                    "RocketMQNodeIAMProfileID": {
+                        "Ref": "RocketMQNodeIAMProfile"
+                    },
+                    "VPC": {
+                        "Ref": "VPC"
+                    },
+                    "VolumeSize": {
+                        "Ref": "VolumeSize"
+                    },
+                    "VolumeType": {
+                        "Ref": "VolumeType"
+                    },
+                    "StackName": {
+                        "Ref": "AWS::StackName"
+                    },
+                    "ImageId": {
+                        "Fn::FindInMap": [
+                            "AWSAMIRegionMap",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            "AMZNLINUX"
+                        ]
+                    },
+                    "ReplicaNodeNameTag": "RocketMQ-NameServer-Node-2",
+                    "NodeReplicaSetIndex": "2",
+                    "ReplicaNodeWaitForNodeInstallWaitHandle": {
+                        "Ref": "RocketMQNameServerNode2WaitForNodeInstallWaitHandle"
+                    }
+                }
+            }
+        },
+        "RocketMQNameServerNode2WaitForNodeInstall": {
+            "Type": "AWS::CloudFormation::WaitCondition",
+            "Condition": "Launch3NameServer",
+            "DependsOn": "RocketMQNameServerNode2",
+            "Properties": {
+                "Handle": {
+                    "Ref": "RocketMQNameServerNode2WaitForNodeInstallWaitHandle"
+                },
+                "Timeout": "3600"
+            }
+        },
+        "PrimaryRocketMQBrokerNode0WaitForNodeInstallWaitHandle": {
+            "Type": "AWS::CloudFormation::WaitConditionHandle",
+            "Properties": {}
+        },
+        "PrimaryRocketMQBrokerNode0": {
+            "Type": "AWS::CloudFormation::Stack",
+            "DependsOn": "RocketMQNameServerNode0",
+            "Properties": {
+                "TemplateURL": {
+                    "Fn::Sub": [
+                        "https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/rocketmq-node-broker.template",
+                        {
+                            "S3Region": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Ref": "AWS::Region" }, {"Ref": "QSS3BucketRegion"}]
+                            },
+                            "S3Bucket": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
+                            }
+                        }
+                    ]
+                },
+                "Parameters": {
+                    "QSS3BucketName": {
+                        "Ref": "QSS3BucketName"
+                    },
+                    "QSS3KeyPrefix": {
+                        "Ref": "QSS3KeyPrefix"
+                    },
+                    "QSS3BucketRegion": {
+                        "Ref": "QSS3BucketRegion"
+                    },
+                    "BrokerClusterCount": {
+                        "Ref": "BrokerClusterCount"
+                    },
+                    "FlushDiskType": {
+                        "Ref": "FlushDiskType"
+                    },
+                    "Iops": {
+                        "Ref": "Iops"
+                    },
+                    "KeyName": {
+                        "Ref": "KeyPairName"
+                    },
+                    "BrokerNodeInstanceType": {
+                        "Ref": "BrokerNodeInstanceType"
+                    },
+                    "RocketMQVersion": {
+                        "Ref": "RocketMQVersion"
+                    },
+                    "NodeSubnet": {
+                        "Ref": "PrimaryNodeSubnet"
+                    },
+                    "RocketMQBrokerServerSecurityGroupID": {
+                        "Ref": "RocketMQBrokerServerSecurityGroup"
+                    },
+                    "RocketMQNodeIAMProfileID": {
+                        "Ref": "RocketMQNodeIAMProfile"
+                    },
+                    "VPC": {
+                        "Ref": "VPC"
+                    },
+                    "VolumeSize": {
+                        "Ref": "VolumeSize"
+                    },
+                    "VolumeType": {
+                        "Ref": "VolumeType"
+                    },
+                    "StackName": {
+                        "Ref": "AWS::StackName"
+                    },
+                    "ImageId": {
+                        "Fn::FindInMap": [
+                            "AWSAMIRegionMap",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            "AMZNLINUX"
+                        ]
+                    },
+                    "ReplicaNodeNameTag": "PrimaryRocketMQ-Broker-Node-0",
+                    "NodeReplicaSetIndex": "0",
+                    "ReplicaNodeWaitForNodeInstallWaitHandle": {
+                        "Ref": "PrimaryRocketMQBrokerNode0WaitForNodeInstallWaitHandle"
+                    }
+                }
+            }
+        },
+        "PrimaryRocketMQBrokerNode0WaitForNodeInstall": {
+            "Type": "AWS::CloudFormation::WaitCondition",
+            "DependsOn": "PrimaryRocketMQBrokerNode0",
+            "Properties": {
+                "Handle": {
+                    "Ref": "PrimaryRocketMQBrokerNode0WaitForNodeInstallWaitHandle"
+                },
+                "Timeout": "3600"
+            }
+        },
+        "SecondaryRocketMQBrokerNode0WaitForNodeInstallWaitHandle": {
+            "Type": "AWS::CloudFormation::WaitConditionHandle",
+            "Properties": {},
+            "Condition": "CreateThreeReplicaSet"
+        },
+        "SecondaryRocketMQBrokerNode0": {
+            "Condition": "CreateThreeReplicaSet",
+            "Type": "AWS::CloudFormation::Stack",
+            "DependsOn": "RocketMQNameServerNode0",
+            "Properties": {
+                "TemplateURL": {
+                    "Fn::Sub": [
+                        "https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/rocketmq-node-broker.template",
+                        {
+                            "S3Region": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Ref": "AWS::Region" }, {"Ref": "QSS3BucketRegion"}]
+                            },
+                            "S3Bucket": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
+                            }
+                        }
+                    ]
+                },
+                "Parameters": {
+                    "QSS3BucketName": {
+                        "Ref": "QSS3BucketName"
+                    },
+                    "QSS3KeyPrefix": {
+                        "Ref": "QSS3KeyPrefix"
+                    },
+                    "QSS3BucketRegion": {
+                        "Ref": "QSS3BucketRegion"
+                    },
+                    "BrokerClusterCount": {
+                        "Ref": "BrokerClusterCount"
+                    },
+                    "FlushDiskType": {
+                        "Ref": "FlushDiskType"
+                    },
+                    "RocketMQVersion": {
+                        "Ref": "RocketMQVersion"
+                    },
+                    "Iops": {
+                        "Ref": "Iops"
+                    },
+                    "KeyName": {
+                        "Ref": "KeyPairName"
+                    },
+                    "BrokerNodeInstanceType": {
+                        "Ref": "BrokerNodeInstanceType"
+                    },
+                    "NodeSubnet": {
+                        "Ref": "Secondary0NodeSubnet"
+                    },
+                    "RocketMQBrokerServerSecurityGroupID": {
+                        "Ref": "RocketMQBrokerServerSecurityGroup"
+                    },
+                    "RocketMQNodeIAMProfileID": {
+                        "Ref": "RocketMQNodeIAMProfile"
+                    },
+                    "VPC": {
+                        "Ref": "VPC"
+                    },
+                    "VolumeSize": {
+                        "Ref": "VolumeSize"
+                    },
+                    "VolumeType": {
+                        "Ref": "VolumeType"
+                    },
+                    "StackName": {
+                        "Ref": "AWS::StackName"
+                    },
+                    "ImageId": {
+                        "Fn::FindInMap": [
+                            "AWSAMIRegionMap",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            "AMZNLINUX"
+                        ]
+                    },
+                    "ReplicaNodeNameTag": "Secondary-RocketMQ-Broker-Node-0",
+                    "NodeReplicaSetIndex": "1",
+                    "ReplicaNodeWaitForNodeInstallWaitHandle": {
+                        "Ref": "SecondaryRocketMQBrokerNode0WaitForNodeInstallWaitHandle"
+                    }
+                }
+            }
+        },
+        "SecondaryRocketMQBrokerNode0WaitForNodeInstall": {
+            "Type": "AWS::CloudFormation::WaitCondition",
+            "Condition": "CreateThreeReplicaSet",
+            "DependsOn": "SecondaryRocketMQBrokerNode0",
+            "Properties": {
+                "Handle": {
+                    "Ref": "SecondaryRocketMQBrokerNode0WaitForNodeInstallWaitHandle"
+                },
+                "Timeout": "3600"
+            }
+        },
+        "SecondaryRocketMQBrokerNode1WaitForNodeInstallWaitHandle": {
+            "Type": "AWS::CloudFormation::WaitConditionHandle",
+            "Properties": {},
+            "Condition": "CreateThreeReplicaSet"
+        },
+        "SecondaryRocketMQBrokerNode1": {
+            "Condition": "CreateThreeReplicaSet",
+            "Type": "AWS::CloudFormation::Stack",
+            "DependsOn": "RocketMQNameServerNode0",
+            "Properties": {
+                "TemplateURL": {
+                    "Fn::Sub": [
+                        "https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}templates/rocketmq-node-broker.template",
+                        {
+                            "S3Region": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Ref": "AWS::Region" }, {"Ref": "QSS3BucketRegion"}]
+                            },
+                            "S3Bucket": {
+                                "Fn::If": ["UsingDefaultBucket",  { "Fn::Sub": "${QSS3BucketName}-${AWS::Region}" }, {"Ref": "QSS3BucketName"}]
+                            }
+                        }
+                    ]
+                },
+                "Parameters": {
+                    "QSS3BucketName": {
+                        "Ref": "QSS3BucketName"
+                    },
+                    "QSS3KeyPrefix": {
+                        "Ref": "QSS3KeyPrefix"
+                    },
+                    "QSS3BucketRegion": {
+                        "Ref": "QSS3BucketRegion"
+                    },
+                    "BrokerClusterCount": {
+                        "Ref": "BrokerClusterCount"
+                    },
+                    "FlushDiskType": {
+                        "Ref": "FlushDiskType"
+                    },
+                    "RocketMQVersion": {
+                        "Ref": "RocketMQVersion"
+                    },
+                    "Iops": {
+                        "Ref": "Iops"
+                    },
+                    "KeyName": {
+                        "Ref": "KeyPairName"
+                    },
+                    "BrokerNodeInstanceType": {
+                        "Ref": "BrokerNodeInstanceType"
+                    },
+                    "NodeSubnet": {
+                        "Ref": "Secondary1NodeSubnet"
+                    },
+                    "RocketMQBrokerServerSecurityGroupID": {
+                        "Ref": "RocketMQBrokerServerSecurityGroup"
+                    },
+                    "RocketMQNodeIAMProfileID": {
+                        "Ref": "RocketMQNodeIAMProfile"
+                    },
+                    "VPC": {
+                        "Ref": "VPC"
+                    },
+                    "VolumeSize": {
+                        "Ref": "VolumeSize"
+                    },
+                    "VolumeType": {
+                        "Ref": "VolumeType"
+                    },
+                    "StackName": {
+                        "Ref": "AWS::StackName"
+                    },
+                    "ImageId": {
+                        "Fn::FindInMap": [
+                            "AWSAMIRegionMap",
+                            {
+                                "Ref": "AWS::Region"
+                            },
+                            "AMZNLINUX"
+                        ]
+                    },
+                    "ReplicaNodeNameTag": "Secondary-RocketMQ-Broker-Node-1",
+                    "NodeReplicaSetIndex": "2",
+                    "ReplicaNodeWaitForNodeInstallWaitHandle": {
+                        "Ref": "SecondaryRocketMQBrokerNode1WaitForNodeInstallWaitHandle"
+                    }
+                }
+            }
+        },
+        "SecondaryRocketMQBrokerNode1WaitForNodeInstall": {
+            "Type": "AWS::CloudFormation::WaitCondition",
+            "Condition": "CreateThreeReplicaSet",
+            "DependsOn": "SecondaryRocketMQBrokerNode1",
+            "Properties": {
+                "Handle": {
+                    "Ref": "SecondaryRocketMQBrokerNode1WaitForNodeInstallWaitHandle"
+                },
+                "Timeout": "3600"
+            }
+        }
+    },
+    "Outputs": {
+        "PrimaryReplicaNodeIp": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "PrimaryRocketMQBrokerNode0",
+                    "Outputs.NodePrivateIp"
+                ]
+            },
+            "Description": "Private IP Address of Primary Replica Node"
+        },
+        "SecondaryRocketMQBrokerNode0Ip": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "SecondaryRocketMQBrokerNode0",
+                    "Outputs.NodePrivateIp"
+                ]
+            },
+            "Description": "Private IP Address of Secondary Replica 0 Node",
+            "Condition": "CreateThreeReplicaSet"
+        },
+        "SecondaryRocketMQBrokerNode1Ip": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "SecondaryRocketMQBrokerNode1",
+                    "Outputs.NodePrivateIp"
+                ]
+            },
+            "Description": "Private IP Address of Secondary Replica 1 Node",
+            "Condition": "CreateThreeReplicaSet"
+        },
+        "RocketMQServerAccessSecurityGroup": {
+            "Value": {
+                "Ref": "RocketMQServerAccessSecurityGroup"
+            },
+            "Description": "Apache RocketMQ Access Security Group"
+        }
+    }
+}

--- a/templates/rocketmq.template
+++ b/templates/rocketmq.template
@@ -230,7 +230,7 @@
         "BrokerNodeInstanceType": {
             "Description": "Amazon EC2 instance type for the RocketMQ nodes.",
             "Type": "String",
-            "Default": "m5.xlarge",
+            "Default": "m5.2xlarge",
             "AllowedValues": [
                 "m5.large",
                 "m5.xlarge",
@@ -414,6 +414,12 @@
             },
             "cn-northwest-1":{
                 "AMZNLINUX": "ami-0c6205ef045ce3916"
+            },
+            "cn-northwest-1":{
+                "AMZNLINUX": "ami-0c6205ef045ce3916"
+            },
+            "eu-west-3":{
+                "AMZNLINUX": "ami-04b7bf9494d21c5bb"
             }
         }
     },


### PR DESCRIPTION
*Description of changes:*

1. Change broker instance default size to m5.2xlarge. m5.xlarge will cause broker bootstrap failure due to OOM
2. Add eu-west-3 AMI id for al2
3. Add Al2 image as an option for bastion host


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
